### PR TITLE
fix(classify): a usage-limit 400 is not a malformed document

### DIFF
--- a/src/commands/spawn/raw_stream_classifier.rs
+++ b/src/commands/spawn/raw_stream_classifier.rs
@@ -141,7 +141,12 @@ fn failure_class_for_signal(
         {
             FailureClass::ApiError5xxTransient
         }
-        FailureReason::Hard if signal.http_status == Some(400) => FailureClass::ApiError400Document,
+        FailureReason::Hard
+            if signal.http_status == Some(400)
+                && text.is_some_and(looks_like_document_error) =>
+        {
+            FailureClass::ApiError400Document
+        }
         _ if text.is_some_and(looks_like_executor_tool_model_config_failure) => {
             FailureClass::ExecutorConfig
         }
@@ -395,6 +400,18 @@ pub fn is_disk_resource_failure(raw_stream: &Path, output_log: &Path) -> bool {
         .any(|path| read_tail(path).is_some_and(|tail| looks_like_disk_exhaustion(&tail)))
 }
 
+/// Does this stream tail show the API rejecting a DOCUMENT (the 400 that means "your PDF is
+/// broken"), as opposed to any other 400?
+///
+/// `status_reason` maps 400..=499 to `FailureReason::Hard` and a present status outranks the
+/// message, so every 4xx without a typed error arrives here as Hard + 400 — a malformed PDF and an
+/// exhausted API budget look identical at this point. Only the message tells them apart.
+fn looks_like_document_error(text: &str) -> bool {
+    ["could not process pdf", "could not process document", "could not process image"]
+        .iter()
+        .any(|needle| text.to_ascii_lowercase().contains(needle))
+}
+
 fn looks_like_executor_tool_model_config_failure(text: &str) -> bool {
     let lower = text.to_ascii_lowercase();
     lower.contains("param: tools")
@@ -424,6 +441,22 @@ mod tests {
         assert_eq!(
             classify_from_raw_stream(f.path(), 1),
             FailureClass::ApiError400Document
+        );
+    }
+
+    #[test]
+    fn test_classifier_400_usage_limit_is_not_a_document_error() {
+        // A real Anthropic usage-limit payload. `status_reason` maps 400..=499 to
+        // FailureReason::Hard, and the message is never consulted because a present status
+        // outranks it, so this arrives as Hard + 400 — indistinguishable from a bad PDF unless
+        // the document arm asks for document evidence.
+        let f = write_stream(
+            r#"{"type":"result","terminal_reason":"api_error","subtype":"success","is_error":true,"api_error_status":400,"result":"API Error: 400 You have reached your specified API usage limits. You will regain access on 2026-09-01 at 00:00 UTC."}"#,
+        );
+        assert_ne!(
+            classify_from_raw_stream(f.path(), 1),
+            FailureClass::ApiError400Document,
+            "an exhausted API budget is not a malformed document"
         );
     }
 
@@ -590,10 +623,12 @@ mod tests {
     fn test_classifier_truncated_jsonl() {
         // Last line is partial JSON — should fall back, not panic
         let f = write_stream(r#"{"type":"result","api_error_status":400,"mes"#);
-        // Still extracts the status code from partial JSON
+        // The status is still extracted from the partial line. The CLASS changes with this commit:
+        // a stream that stops mid-key carries no evidence of WHY the request was rejected, so it
+        // is no longer reported as a document error. Only a message naming a document earns that.
         assert_eq!(
             classify_from_raw_stream(f.path(), 1),
-            FailureClass::ApiError400Document
+            FailureClass::AgentExitNonzero
         );
     }
 


### PR DESCRIPTION
## The bug

An exhausted API budget is reported as a malformed document.

`status_reason` maps `400..=499` to `FailureReason::Hard`, and in `failure_signal_*` a present
status outranks the message (`if let Some(status) … else if typed_reason … else if
substring_reason`). So every 4xx without a typed error arrives at the classifier as `Hard` +
`http_status: Some(400)`, where this arm caught all of them:

```rust
FailureReason::Hard if signal.http_status == Some(400) => FailureClass::ApiError400Document,
```

A real payload from a worker that hit its account cap:

```json
{"type":"result","terminal_reason":"api_error","subtype":"success","is_error":true,
 "api_error_status":400,
 "result":"API Error: 400 You have reached your specified API usage limits. You will regain access on 2026-09-01 at 00:00 UTC."}
```

That is classified `api-error-400-document`. Two consequences:

1. **The operator is sent to fix a file that does not exist.** `wg show` prints the document hint —
   "fix the input (malformed/encrypted PDF or document) before retry". There is no document
   anywhere in the task.
2. **The task is charged for the provider's state.** Downstream, the document class is treated as a
   task-fatal condition (in our deployment it maps to a `FatalTask` provider-error kind), so the
   task is failed permanently. With the budget gone, every queued task lines up for the same
   treatment: a single account-level wall is recorded as N separate bad-input failures.

We hit this in a live deployment on 2026-08-11. One task was marked failed with a hint pointing at
a PDF; the account had simply run out of budget until the 1st of the following month.

## The fix

Make the document class require document evidence, using the `text` this function already receives
and the fall-through arms that already exist:

```rust
FailureReason::Hard
    if signal.http_status == Some(400)
        && text.is_some_and(looks_like_document_error) =>
{
    FailureClass::ApiError400Document
}
```

`looks_like_document_error` matches the same three markers the code already looked for
(`Could not process PDF` / `document` / `image`), in the shape of the neighbouring
`looks_like_executor_tool_model_config_failure` predicate. Unrecognised 400s now fall through to
the existing `ExecutorConfig` / `WrapperInternal` / `AgentExitNonzero` arms instead of being named
as something nobody checked.

No new enum variant, no new policy, no change to any other status.

## Behaviour change, and the test that documented the old assumption

`test_classifier_truncated_jsonl` fed a stream cut off mid-key (`{"type":"result","api_error_status":400,"mes`)
and asserted `ApiError400Document`. A truncated stream carries no evidence of *why* the request was
rejected, so that assertion was the same unearned diagnosis this patch removes; it now expects
`AgentExitNonzero`. That is the only intentional behaviour change beyond the guard.

## Verification

Run on macOS (arm64), on `main` + the `pipe2` build fix from #62 applied locally — **without that,
`cargo test` on `main` does not compile on macOS at all** (`cannot find function pipe2 in crate
libc`), which is worth knowing independently of this PR.

| | passed | failed |
|---|---:|---:|
| `cargo test --bin wg` before | 3739 | 18 |
| `cargo test --bin wg` after | 3740 | 18 |

The 18 failures are a pre-existing macOS baseline (8 in `commands::service::worktree::tests`, plus
`agency_remote`, `chat::test_generate_request_id_unique`, `doctor::pi_guard_*`,
`publish::publish_run_with_mkpath_*` and others). The failing SETS before and after are identical,
compared name by name — this patch changes no outcome except the classifier module, which goes
21/21. The +1 passed is the new test.

(One of four runs on this machine reported a 19th failure that did not recur in the other three; I
did not capture which test it was, so I mention it only because it bears on how you read these
numbers — the macOS suite appears to have at least one intermittent of its own.)

## Two things noted, not fixed

Both are adjacent and are yours to judge, so they are not in this patch:

1. **A usage-limit 400 still ends up in `AgentExitNonzero`.** You already have the right vocabulary
   for it — `FailureReason::CreditExhausted` and `QuotaToken` — and `substring_reason` already
   matches "insufficient credits" / "out of credits" / "payment required" / "insufficient_quota".
   Adding "usage limit" to that list would not help, because the status outranks the message for a
   400; recognising the quota case would need the message consulted when a status maps only to the
   catch-all `Hard`. That is a precedence decision, not a bug fix, so it is left alone.
2. **`consecutive_credit_exhausted` appears to be write-only.** `TelemetryAggregate::observe`
   increments and resets it, and nothing in the tree reads it — so today a genuinely detected
   credit exhaustion has no effect on dispatch either.
